### PR TITLE
Switch to ensureDBOwnership, ensurePermissions is being deprecated

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -87,7 +87,7 @@ in
       ensureDatabases = [ "glitchtip" ];
       ensureUsers = [{
         name = "glitchtip";
-        ensurePermissions = { "DATABASE glitchtip" = "ALL PRIVILEGES"; };
+        ensureDBOwnership = true;
       }];
     };
 


### PR DESCRIPTION
At the moment ensurePermissions doesn't work on PostgreSQL ≥15, and might be removed in NixOS 24.05.