### PR TITLE
Activate entry-point that runs DB migrations

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -105,7 +105,7 @@ in
         image = "glitchtip/glitchtip";
         autoStart = true;
         ports = [ "8080:8080/tcp" ];
-        # entrypoint = "./bin/run-migrate-and-runserver.sh";
+        entrypoint = "./bin/run-migrate-and-runserver.sh";
         environmentFiles = [
           config.age.secrets."glitchtip/credentials".path
         ];


### PR DESCRIPTION
Without this change the initial migrations creating the DB aren't run, and I suspect migrations for newer versions either.